### PR TITLE
fix: error when .github directory doesn't exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "0.1.0"
 dependencies = [
  "heck",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -46,8 +46,6 @@ impl Generate {
             .join("workflows")
             .join(self.name.as_str());
 
-        let path = path.canonicalize()?;
-
         let content = format!("{}\n{}", comment, self.workflow.to_string()?);
 
         let result = self.check_file(&path, &content);

--- a/tests/test-workflow.rs
+++ b/tests/test-workflow.rs
@@ -1,38 +1,35 @@
-#[cfg(test)]
-mod test {
-    use gh_workflow::Workflow;
-    use pretty_assertions::assert_eq;
-    use serde_json::Value;
+use gh_workflow::Workflow;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
 
-    fn split(content: &str) -> (Value, Value) {
-        let parsed = Workflow::parse(content).unwrap();
-        let actual = serde_yaml::from_str::<Value>(&parsed.to_string().unwrap()).unwrap();
-        let expected = serde_yaml::from_str::<Value>(content).unwrap();
+fn split(content: &str) -> (Value, Value) {
+    let parsed = Workflow::parse(content).unwrap();
+    let actual = serde_yaml::from_str::<Value>(&parsed.to_string().unwrap()).unwrap();
+    let expected = serde_yaml::from_str::<Value>(content).unwrap();
 
-        (actual, expected)
-    }
+    (actual, expected)
+}
 
-    #[test]
-    fn test_workflow_bench() {
-        let (actual, expected) = split(include_str!("./fixtures/workflow-bench.yml"));
-        assert_eq!(actual, expected);
-    }
+#[test]
+fn test_workflow_bench() {
+    let (actual, expected) = split(include_str!("./fixtures/workflow-bench.yml"));
+    assert_eq!(actual, expected);
+}
 
-    #[test]
-    fn test_workflow_ci() {
-        let (actual, expected) = split(include_str!("./fixtures/workflow-ci.yml"));
-        assert_eq!(actual, expected);
-    }
+#[test]
+fn test_workflow_ci() {
+    let (actual, expected) = split(include_str!("./fixtures/workflow-ci.yml"));
+    assert_eq!(actual, expected);
+}
 
-    #[test]
-    fn test_workflow_demo() {
-        let (actual, expected) = split(include_str!("./fixtures/workflow-demo.yml"));
-        assert_eq!(actual, expected);
-    }
+#[test]
+fn test_workflow_demo() {
+    let (actual, expected) = split(include_str!("./fixtures/workflow-demo.yml"));
+    assert_eq!(actual, expected);
+}
 
-    #[test]
-    fn test_workflow_rust() {
-        let (actual, expected) = split(include_str!("./fixtures/workflow-rust.yml"));
-        assert_eq!(actual, expected);
-    }
+#[test]
+fn test_workflow_rust() {
+    let (actual, expected) = split(include_str!("./fixtures/workflow-rust.yml"));
+    assert_eq!(actual, expected);
 }


### PR DESCRIPTION
The call `path.canonicalize` will error in case the path doesn't exist. 

Remove this call to handle it properly. I'm not sure if the call for canonicalize is really required in this context