### PR TITLE
feat: make `to_ci_workflow` public

### DIFF
--- a/crates/gh-workflow-tailcall/src/workflow.rs
+++ b/crates/gh-workflow-tailcall/src/workflow.rs
@@ -62,7 +62,7 @@ impl Workflow {
     }
 
     /// Converts the workflow into a Github workflow.
-    fn to_ci_workflow(&self) -> GHWorkflow {
+    pub fn to_ci_workflow(&self) -> GHWorkflow {
         GHWorkflow::new(self.name.clone())
             .add_env(self.workflow_flags())
             .on(self.workflow_event())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Made the `to_ci_workflow` method publicly accessible, allowing external usage of the method for generating CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->