### PR TITLE
drop when

### DIFF
--- a/crates/gh-workflow-tailcall/src/standard.rs
+++ b/crates/gh-workflow-tailcall/src/standard.rs
@@ -170,14 +170,14 @@ impl StandardWorkflow {
                     "target".into(),
                 ]),
         );
-        
+
         // Add cargo fmt step
         if auto_fix {
             job = job.add_step(
                 Cargo::new("fmt")
                     .name("Cargo Fmt")
                     .nightly()
-                    .add_args("--all")
+                    .add_args("--all"),
             );
         } else {
             job = job.add_step(
@@ -185,10 +185,10 @@ impl StandardWorkflow {
                     .name("Cargo Fmt")
                     .nightly()
                     .add_args("--all")
-                    .add_args("--check")
+                    .add_args("--check"),
             );
         }
-        
+
         // Add cargo clippy step
         if auto_fix {
             job = job.add_step(
@@ -197,14 +197,14 @@ impl StandardWorkflow {
                     .nightly()
                     .add_args("--fix")
                     .add_args("--allow-dirty")
-                    .add_args("--all-features --workspace -- -D warnings")
+                    .add_args("--all-features --workspace -- -D warnings"),
             );
         } else {
             job = job.add_step(
                 Cargo::new("clippy")
                     .name("Cargo Clippy")
                     .nightly()
-                    .add_args("--all-features --workspace -- -D warnings")
+                    .add_args("--all-features --workspace -- -D warnings"),
             );
         }
 

--- a/crates/gh-workflow/src/cargo.rs
+++ b/crates/gh-workflow/src/cargo.rs
@@ -59,14 +59,7 @@ impl Cargo {
         self
     }
 
-    /// Adds the arguments to the cargo command when a condition is met.
-    pub fn add_args_when<T: ToString>(self, when: bool, args: T) -> Self {
-        if when {
-            self.add_args(args)
-        } else {
-            self
-        }
-    }
+
 }
 
 impl From<Cargo> for Step<Run> {

--- a/crates/gh-workflow/src/cargo.rs
+++ b/crates/gh-workflow/src/cargo.rs
@@ -58,8 +58,6 @@ impl Cargo {
         );
         self
     }
-
-
 }
 
 impl From<Cargo> for Step<Run> {

--- a/crates/gh-workflow/src/workflow.rs
+++ b/crates/gh-workflow/src/workflow.rs
@@ -114,14 +114,7 @@ impl Workflow {
         Ok(serde_yaml::to_string(self)?)
     }
 
-    /// Adds a job to the workflow when a condition is met.
-    pub fn add_job_when<T: ToString, J: Into<Job>>(self, cond: bool, id: T, job: J) -> Self {
-        if cond {
-            self.add_job(id, job)
-        } else {
-            self
-        }
-    }
+
 
     /// Adds a job to the workflow with the specified ID and job configuration.
     pub fn add_job<T: ToString, J: Into<Job>>(mut self, id: T, job: J) -> Self {
@@ -155,14 +148,7 @@ impl Workflow {
         self
     }
 
-    /// Adds an event to the workflow when a condition is met.
-    pub fn add_event_when<T: Into<Event>>(self, cond: bool, that: T) -> Self {
-        if cond {
-            self.add_event(that)
-        } else {
-            self
-        }
-    }
+
 
     /// Adds an environment variable to the workflow.
     pub fn add_env<T: Into<Env>>(mut self, new_env: T) -> Self {
@@ -173,14 +159,7 @@ impl Workflow {
         self
     }
 
-    /// Adds an environment variable to the workflow when a condition is met.
-    pub fn add_env_when<T: Into<Env>>(self, cond: bool, new_env: T) -> Self {
-        if cond {
-            self.add_env(new_env)
-        } else {
-            self
-        }
-    }
+
 
     /// Performs a reverse lookup to get the ID of a job.
     pub fn get_id(&self, job: &Job) -> Option<&str> {
@@ -277,14 +256,7 @@ impl Job {
         }
     }
 
-    /// Adds a step to the job when a condition is met.
-    pub fn add_step_when<S: Into<Step<T>>, T: StepType>(self, cond: bool, step: S) -> Self {
-        if cond {
-            self.add_step(step)
-        } else {
-            self
-        }
-    }
+
 
     /// Adds a step to the job.
     pub fn add_step<S: Into<Step<T>>, T: StepType>(mut self, step: S) -> Self {
@@ -305,14 +277,7 @@ impl Job {
         self
     }
 
-    /// Adds an environment variable to the job when a condition is met.
-    pub fn add_env_when<T: Into<Env>>(self, cond: bool, new_env: T) -> Self {
-        if cond {
-            self.add_env(new_env)
-        } else {
-            self
-        }
-    }
+
 
     /// Add multiple steps to the job at once.
     ///
@@ -333,14 +298,7 @@ impl Job {
         self
     }
 
-    /// Adds a dependency to the job when a condition is met.
-    pub fn add_needs_when<T: Into<Job>>(self, cond: bool, needs: T) -> Self {
-        if cond {
-            self.add_needs(needs)
-        } else {
-            self
-        }
-    }
+
 }
 
 /// Represents a step in the workflow.
@@ -603,14 +561,7 @@ impl Step<Use> {
         self
     }
 
-    /// Adds a new input to the step when a condition is met.
-    pub fn add_with_when<I: Into<Input>>(self, cond: bool, new_with: I) -> Self {
-        if cond {
-            self.add_with(new_with)
-        } else {
-            self
-        }
-    }
+
 }
 
 /// Represents a key-value pair for inputs.

--- a/crates/gh-workflow/src/workflow.rs
+++ b/crates/gh-workflow/src/workflow.rs
@@ -114,8 +114,6 @@ impl Workflow {
         Ok(serde_yaml::to_string(self)?)
     }
 
-
-
     /// Adds a job to the workflow with the specified ID and job configuration.
     pub fn add_job<T: ToString, J: Into<Job>>(mut self, id: T, job: J) -> Self {
         let key = id.to_string();
@@ -148,8 +146,6 @@ impl Workflow {
         self
     }
 
-
-
     /// Adds an environment variable to the workflow.
     pub fn add_env<T: Into<Env>>(mut self, new_env: T) -> Self {
         let mut env = self.env.unwrap_or_default();
@@ -158,8 +154,6 @@ impl Workflow {
         self.env = Some(env);
         self
     }
-
-
 
     /// Performs a reverse lookup to get the ID of a job.
     pub fn get_id(&self, job: &Job) -> Option<&str> {
@@ -256,8 +250,6 @@ impl Job {
         }
     }
 
-
-
     /// Adds a step to the job.
     pub fn add_step<S: Into<Step<T>>, T: StepType>(mut self, step: S) -> Self {
         let mut steps = self.steps.unwrap_or_default();
@@ -277,8 +269,6 @@ impl Job {
         self
     }
 
-
-
     /// Add multiple steps to the job at once.
     ///
     /// This is a convenience method that takes a vector of steps and adds them
@@ -297,8 +287,6 @@ impl Job {
         self.tmp_needs = Some(needs);
         self
     }
-
-
 }
 
 /// Represents a step in the workflow.
@@ -560,8 +548,6 @@ impl Step<Use> {
 
         self
     }
-
-
 }
 
 /// Represents a key-value pair for inputs.


### PR DESCRIPTION
- **chore: update ci**
- **lint fixes**
- **chore: update cargo**
- **chore: update permissions**
- **feat: add more APIs on ctx**
- **refactor: rename Expr to Context**
- **doc: update documentation**
- **chore: update release config**
- **chore: update condition for release build**
- **chore: update changelog template**
- **chore: use default .release-plz.toml**
- **chore: rename workflow name**
- **chore: fix workflow name**
- **chore: release v0.5.0 (#77)**
- **chore: disable publish for macros**
- **chore: revert version**
- **chore: release v0.5.0 (#78)**
- **chore: revert version**
- **chore: release v0.5.0 (#79)**
- **chore: update release config**
- **chore: disable release for macros**
- **chore: enable release always**
- **chore: move macros to dev deps**
- **chore: add workspaces back**
- **chore: update release config**
- **chore: update release config**
- **chore: add version to macros**
- **chore: move macros to deps**
- **chore: reset release flags**
- **chore: release v0.5.0 (#82)**
- **chore: update workflow for release**
- **chore: add concurrency in release**
- **chore: revert commit**
- **chore: release macros also**
- **chore: release v0.5.0 (#84)**
- **chore: update dependencies**
- **chore: run release only when build is successfull**
- **chore: run release on main only**
- **chore: enable macros to be published**
- **chore: add metadata fields to Cargo.toml for gh-workflow and gh-workflow-macros**
- **chore(gh-workflow-macros): release v0.5.0 (#86)**
- **chore: release v0.5.1 (#87)**
- **doc: add module documentation for gh-workflow**
- **feat: add gh-workflow-tailcall**
- **doc: improve documentation for TailcallWorkflow**
- **refactor: use gh-workflow-tailcall in the test**
- **chore: release (#91)**
- **doc: update readme**
- **fix: drop `v` prefix from `uses` API**
- **chore: release (#92)**
- **fix: jobs dependency id generator (#94)**
- **chore: release (#95)**
- **chore: add readme**
- **chore: release (#96)**
- **feat: add benchmark to workflow (#97)**
- **feat: add support to conditionally add components (#100)**
- **fix(deps): update rust crate serde to v1.0.216**
- **refactor(cargo): Trim and filter empty arguments in command generation**
- **feat: support auto-fix fixes #55**
- **chore: enable auto-fix**
- **refactor: restructure workflow.rs**
- **chore: setup toolchain**
- **fix: order of clippy arguments**
- **fix: parameter information for add_step_when**
- **refactor: add `autofix-ci` step**
- **chore: update ci.yml**
- **chore: add allow-dirty**
- **chore: add autofix.yml**
- **[autofix.ci] apply automated fixes**
- **[autofix.ci] apply automated fixes (attempt 2/3)**
- **chore: update workflow name**
- **chore: add concurrency in autofix**
- **chore: update workflow name**
- **fix: handle duplicate jobs**
- **[autofix.ci] apply automated fixes**
- **[autofix.ci] apply automated fixes (attempt 2/3)**
- **fix: avoid job duplication**
- **fix: resolve conflict remanants**
- **[autofix.ci] apply automated fixes**
- **chore: rename workflow name**
- **chore: unset release_always**
- **chore: release (#109)**
- **Update README.md**
- **test: add test for duplicated jobs (#112)**
- **feat: make `to_ci_workflow` public (#114)**
- **fix(deps): update rust crate serde to v1.0.217 (#113)**
- **fix(deps): update rust crate serde_json to v1.0.134 (#111)**
- **chore: release (#116)**
- **feat: add setup steps to Workflow for job initialization**
- **chore(deps): update rust crate insta to v1.42.0 (#119)**
- **chore(gh-workflow-tailcall): release v0.3.0 (#122)**
- **feat: enable automerge for minor and patch updates in Renovate configuration**
- **refactor: rename Workflow to StandardWorkflow for clarity and consistency**
- **fix: update autofix-ci/action version in workflow files**
- **chore(gh-workflow-tailcall): release v0.4.0 (#126)**
- **refactor: rename module from Workflow to Standard for consistency**
- **feat: add caching support for Cargo toolchain in CI workflows**
- **chore: release (#127)**
- **fix(deps): update rust crate serde_json to v1.0.136 (#120)**
- **feat: add convenience method to add multiple steps to a job**
- **docs: improve documentation for StepValue and Step run methods**
- **refactor: rename new method to run in Cargo struct**
- **docs: remove outdated examples from StepValue and Step run methods**
- **feat: add support for cargo-nextest as an alternative test runner**
- **refactor: rename Cargo::run method to Cargo::new for clarity**
- **fix: correct cargo install command in CI workflow and standard workflow**
- **chore: release (#129)**
- **fix(deps): update rust crate indexmap to v2.7.1 (#130)**
- **fix(deps): update rust crate serde_json to v1.0.137 (#131)**
- **chore(deps): update rust crate insta to v1.42.1 (#132)**
- **fix(deps): update rust crate serde_json to v1.0.138 (#133)**
- **feat: add get method to Jobs struct for retrieving jobs by key (#134)**
- **chore: release (#135)**
- **fix(deps): update rust crate async-trait to v0.1.86 (#136)**
- **fix(deps): update rust crate derive_more to v2 (#138)**
- **fix(deps): update rust crate strum_macros to 0.27.0 (#140)**
- **fix(deps): update rust crate strum_macros to v0.27.1 (#142)**
- **fix(deps): update rust crate serde to v1.0.218 (#144)**
- **fix(deps): update rust crate serde_json to v1.0.139 (#145)**
- **chore(deps): update rust crate insta to v1.42.2 (#148)**
- **feat(event): add tags filter to Push struct for event handling (#157)**
- **chore: release (#158)**
- **fix(deps): update rust crate strum_macros to v0.27.2 (#160)**
- **feat(ci): add caching for Rust dependencies in CI workflow**
- **chore(gh-workflow-tailcall): release v0.5.3 (#161)**
- **chore: use toolchain to setup cargo nextest**
- **Revert "chore: use toolchain to setup cargo nextest"**
- **chore(deps): update actions/checkout action to v5 (#162)**
- **chore: release (#164)**
- **refactor: drop when**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined CI workflow assembly: release jobs are added only when auto‑release is enabled; autofix, tests, and benches run only when configured. Default behavior remains unchanged.
  - Removed conditional helper APIs for chaining; consumers should handle conditions explicitly when adding jobs, steps, env, needs, and Cargo args.
- Chores
  - Internal restructuring for clearer control flow without altering generated workflow outcomes in typical setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->