### PR TITLE
fix schedule type

### DIFF
--- a/crates/gh-workflow/src/event.rs
+++ b/crates/gh-workflow/src/event.rs
@@ -66,7 +66,7 @@ pub struct Event {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository_dispatch: Option<RepositoryDispatch>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub schedule: Option<Schedule>,
+    pub schedule: Option<Vec<Schedule>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -753,15 +753,7 @@ impl RepositoryDispatch {
 #[derive(Debug, Clone, Default, Deserialize, Serialize, Setters, PartialEq, Eq)]
 #[setters(strip_option, into)]
 pub struct Schedule {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub cron: Vec<String>,
-}
-
-impl Schedule {
-    pub fn add_cron<S: Into<String>>(mut self, cron: S) -> Self {
-        self.cron.push(cron.into());
-        self
-    }
+    pub cron: String,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, Setters, PartialEq, Eq)]


### PR DESCRIPTION
- **chore: update ci**
- **lint fixes**
- **chore: update cargo**
- **chore: update permissions**
- **feat: add more APIs on ctx**
- **refactor: rename Expr to Context**
- **doc: update documentation**
- **chore: update release config**
- **chore: update condition for release build**
- **chore: update changelog template**
- **chore: use default .release-plz.toml**
- **chore: rename workflow name**
- **chore: fix workflow name**
- **chore: release v0.5.0 (#77)**
- **chore: disable publish for macros**
- **chore: revert version**
- **chore: release v0.5.0 (#78)**
- **chore: revert version**
- **chore: release v0.5.0 (#79)**
- **chore: update release config**
- **chore: disable release for macros**
- **chore: enable release always**
- **chore: move macros to dev deps**
- **chore: add workspaces back**
- **chore: update release config**
- **chore: update release config**
- **chore: add version to macros**
- **chore: move macros to deps**
- **chore: reset release flags**
- **chore: release v0.5.0 (#82)**
- **chore: update workflow for release**
- **chore: add concurrency in release**
- **chore: revert commit**
- **chore: release macros also**
- **chore: release v0.5.0 (#84)**
- **chore: update dependencies**
- **chore: run release only when build is successfull**
- **chore: run release on main only**
- **chore: enable macros to be published**
- **chore: add metadata fields to Cargo.toml for gh-workflow and gh-workflow-macros**
- **chore(gh-workflow-macros): release v0.5.0 (#86)**
- **chore: release v0.5.1 (#87)**
- **doc: add module documentation for gh-workflow**
- **feat: add gh-workflow-tailcall**
- **doc: improve documentation for TailcallWorkflow**
- **refactor: use gh-workflow-tailcall in the test**
- **chore: release (#91)**
- **doc: update readme**
- **fix: drop `v` prefix from `uses` API**
- **chore: release (#92)**
- **fix: jobs dependency id generator (#94)**
- **chore: release (#95)**
- **chore: add readme**
- **chore: release (#96)**
- **feat: add benchmark to workflow (#97)**
- **feat: add support to conditionally add components (#100)**
- **fix(deps): update rust crate serde to v1.0.216**
- **refactor(cargo): Trim and filter empty arguments in command generation**
- **feat: support auto-fix fixes #55**
- **chore: enable auto-fix**
- **refactor: restructure workflow.rs**
- **chore: setup toolchain**
- **fix: order of clippy arguments**
- **fix: parameter information for add_step_when**
- **refactor: add `autofix-ci` step**
- **chore: update ci.yml**
- **chore: add allow-dirty**
- **chore: add autofix.yml**
- **[autofix.ci] apply automated fixes**
- **[autofix.ci] apply automated fixes (attempt 2/3)**
- **chore: update workflow name**
- **chore: add concurrency in autofix**
- **chore: update workflow name**
- **fix: handle duplicate jobs**
- **[autofix.ci] apply automated fixes**
- **[autofix.ci] apply automated fixes (attempt 2/3)**
- **fix: avoid job duplication**
- **fix: resolve conflict remanants**
- **[autofix.ci] apply automated fixes**
- **chore: rename workflow name**
- **chore: unset release_always**
- **chore: release (#109)**
- **Update README.md**
- **test: add test for duplicated jobs (#112)**
- **feat: make `to_ci_workflow` public (#114)**
- **fix(deps): update rust crate serde to v1.0.217 (#113)**
- **fix(deps): update rust crate serde_json to v1.0.134 (#111)**
- **chore: release (#116)**
- **feat: add setup steps to Workflow for job initialization**
- **chore(deps): update rust crate insta to v1.42.0 (#119)**
- **chore(gh-workflow-tailcall): release v0.3.0 (#122)**
- **feat: enable automerge for minor and patch updates in Renovate configuration**
- **refactor: rename Workflow to StandardWorkflow for clarity and consistency**
- **fix: update autofix-ci/action version in workflow files**
- **chore(gh-workflow-tailcall): release v0.4.0 (#126)**
- **refactor: rename module from Workflow to Standard for consistency**
- **feat: add caching support for Cargo toolchain in CI workflows**
- **chore: release (#127)**
- **fix(deps): update rust crate serde_json to v1.0.136 (#120)**
- **feat: add convenience method to add multiple steps to a job**
- **docs: improve documentation for StepValue and Step run methods**
- **refactor: rename new method to run in Cargo struct**
- **docs: remove outdated examples from StepValue and Step run methods**
- **feat: add support for cargo-nextest as an alternative test runner**
- **refactor: rename Cargo::run method to Cargo::new for clarity**
- **fix: correct cargo install command in CI workflow and standard workflow**
- **chore: release (#129)**
- **fix(deps): update rust crate indexmap to v2.7.1 (#130)**
- **fix(deps): update rust crate serde_json to v1.0.137 (#131)**
- **chore(deps): update rust crate insta to v1.42.1 (#132)**
- **fix(deps): update rust crate serde_json to v1.0.138 (#133)**
- **feat: add get method to Jobs struct for retrieving jobs by key (#134)**
- **chore: release (#135)**
- **fix(deps): update rust crate async-trait to v0.1.86 (#136)**
- **fix(deps): update rust crate derive_more to v2 (#138)**
- **fix(deps): update rust crate strum_macros to 0.27.0 (#140)**
- **fix(deps): update rust crate strum_macros to v0.27.1 (#142)**
- **fix(deps): update rust crate serde to v1.0.218 (#144)**
- **fix(deps): update rust crate serde_json to v1.0.139 (#145)**
- **chore(deps): update rust crate insta to v1.42.2 (#148)**
- **feat(event): add tags filter to Push struct for event handling (#157)**
- **chore: release (#158)**
- **fix(deps): update rust crate strum_macros to v0.27.2 (#160)**
- **feat(ci): add caching for Rust dependencies in CI workflow**
- **chore(gh-workflow-tailcall): release v0.5.3 (#161)**
- **chore: use toolchain to setup cargo nextest**
- **Revert "chore: use toolchain to setup cargo nextest"**
- **chore(deps): update actions/checkout action to v5 (#162)**
- **chore: release (#164)**
- **refactor: improve API ergonomics with builder pattern and method chaining (#165)**
- **chore: release (#168)**
- **refactor: enhance workflow setup in README for improved clarity and functionality**
- **fix: support vec for schedule type**
