### PR TITLE
chore: ignore generated workflow files in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "platformAutomerge": true,
+  "ignorePaths": [".github/workflows/**"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Summary
Configure Renovate to skip `.github/workflows/**` so it no longer opens update PRs against generated workflow files.

## Testing
Validate the config with Renovate's config validator and confirm subsequent Renovate runs no longer propose changes under `.github/workflows/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration to exclude GitHub workflow files from processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->