### PR TITLE
Improve ergonomics when working with reusable workflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/*"]
 # Core dependencies
 async-trait = "0.1.89"
 derive_more = { version = "2.0.1", features = ["from", "deref", "deref_mut"] }
-derive_setters = "0.1.8"
+derive_setters = "0.1.9"
 heck = "0.5.0"
 indexmap = { version = "2.12.0", features = ["serde"] }
 merge = "0.2.0"

--- a/crates/gh-workflow/src/job.rs
+++ b/crates/gh-workflow/src/job.rs
@@ -10,8 +10,8 @@ use serde_json::Value;
 use crate::concurrency::Concurrency;
 use crate::step::{Step, StepType, StepValue};
 use crate::{
-    Artifacts, Container, Defaults, Env, Expression, Input, Permissions, RetryStrategy, Secrets,
-    Strategy,
+    private, Artifacts, Container, Defaults, Env, Expression, Input, Permissions, RetryStrategy,
+    Secrets, Strategy,
 };
 
 /// Represents the environment in which a job runs.
@@ -29,26 +29,26 @@ where
     }
 }
 
-/// Represents a job in the workflow.
-/// Field order matches GitHub Actions YAML structure for better readability.
-#[derive(Debug, Setters, Serialize, Deserialize, Clone, PartialEq, Eq)]
+/// A trait implemented by the different kinds of jobs (`RunJob` and
+/// `UsesJob`) to convert them into a serializable `JobValue`.
+pub trait JobType: Default + private::Sealed {
+    /// Converts a job to its value representation.
+    fn to_value(j: Job<Self>) -> JobValue;
+}
+
+/// Configuration specific to jobs that run steps.
+#[derive(Debug, Clone, Setters, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[setters(strip_option, into)]
-pub struct Job {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub needs: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "if")]
-    pub cond: Option<Expression>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+#[setters(
+    strip_option,
+    into,
+    generate_delegates(ty = "Job<RunJob>", field = "config")
+)]
+pub struct RunJob {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runs_on: Option<RunsOn>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub permissions: Option<Permissions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<crate::Environment>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub concurrency: Option<Concurrency>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub outputs: Option<IndexMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,32 +64,19 @@ pub struct Job {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub services: Option<IndexMap<String, Container>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub strategy: Option<Strategy>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub steps: Option<Vec<StepValue>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uses: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub secrets: Option<Secrets>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry: Option<RetryStrategy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifacts: Option<Artifacts>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub with: Option<Input>,
 }
 
-impl Default for Job {
-    /// Creates a default `Job` with `runs_on` set to "ubuntu-latest".
+impl Default for RunJob {
+    /// Creates a default `RunJob` with `runs_on` set to "ubuntu-latest".
     fn default() -> Self {
         Self {
-            needs: None,
-            cond: None,
-            name: None,
             runs_on: Some(RunsOn(Value::from("ubuntu-latest"))),
-            permissions: None,
             environment: None,
-            concurrency: None,
             outputs: None,
             env: None,
             defaults: None,
@@ -97,79 +84,242 @@ impl Default for Job {
             continue_on_error: None,
             container: None,
             services: None,
-            strategy: None,
             steps: None,
-            uses: None,
-            secrets: None,
             retry: None,
             artifacts: None,
-            with: None,
         }
     }
+}
+
+/// Configuration specific to jobs that call a reusable workflow.
+#[derive(Debug, Clone, Default, Setters, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+#[setters(
+    strip_option,
+    into,
+    generate_delegates(ty = "Job<UsesJob>", field = "config")
+)]
+pub struct UsesJob {
+    #[setters(skip)]
+    pub uses: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub with: Option<Input>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<Secrets>,
+}
+
+impl private::Sealed for RunJob {}
+impl private::Sealed for UsesJob {}
+
+impl JobType for RunJob {
+    fn to_value(j: Job<Self>) -> JobValue {
+        let Self {
+            runs_on,
+            environment,
+            outputs,
+            env,
+            defaults,
+            timeout_minutes,
+            continue_on_error,
+            container,
+            services,
+            steps,
+            retry,
+            artifacts,
+        } = j.config;
+        JobValue {
+            runs_on,
+            environment,
+            outputs,
+            env,
+            defaults,
+            timeout_minutes,
+            continue_on_error,
+            container,
+            services,
+            steps,
+            retry,
+            artifacts,
+            ..j.value
+        }
+    }
+}
+
+impl JobType for UsesJob {
+    fn to_value(j: Job<Self>) -> JobValue {
+        let Self { uses, with, secrets } = j.config;
+        JobValue { uses: Some(uses), with, secrets, ..j.value }
+    }
+}
+
+/// Represents a job in the workflow.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Job<J: JobType = RunJob> {
+    #[serde(flatten)]
+    config: J,
+    #[serde(flatten)]
+    value: JobValue,
+}
+
+/// The serializable value of a job in the workflow.
+/// Field order matches GitHub Actions YAML structure for better readability.
+#[derive(Debug, Setters, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+#[setters(
+    strip_option,
+    into,
+    generate_delegates(ty = "Job<T>", generics = "<T: JobType>", field = "value")
+)]
+pub struct JobValue {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub needs: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "if")]
+    pub cond: Option<Expression>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub runs_on: Option<RunsOn>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Permissions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub environment: Option<crate::Environment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<Concurrency>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub outputs: Option<IndexMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub env: Option<Env>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub defaults: Option<Defaults>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub timeout_minutes: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub continue_on_error: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub container: Option<Container>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub services: Option<IndexMap<String, Container>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<Strategy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub steps: Option<Vec<StepValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub uses: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub secrets: Option<Secrets>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub retry: Option<RetryStrategy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub artifacts: Option<Artifacts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[setters(skip)]
+    pub with: Option<Input>,
 }
 
 impl Job {
     /// Creates a new `Job` with the specified name and default settings.
     pub fn new<T: ToString>(name: T) -> Self {
         Self {
-            name: Some(name.to_string()),
-            runs_on: Some(RunsOn(Value::from("ubuntu-latest"))),
+            value: JobValue { name: Some(name.to_string()), ..Default::default() },
             ..Default::default()
         }
     }
 
-    /// Adds a step to the job.
-    pub fn add_step<S: Into<Step<T>>, T: StepType>(mut self, step: S) -> Self {
-        let mut steps = self.steps.take().unwrap_or_default();
-        let step: Step<T> = step.into();
-        let step: StepValue = T::to_value(step);
-        steps.push(step);
-        self.steps = Some(steps);
-        self
+    /// Creates a new `Job` that calls a reusable workflow.
+    pub fn uses<Owner: ToString, Repo: ToString, Path: ToString, Version: ToString>(
+        self,
+        owner: Owner,
+        repo: Repo,
+        path: Path,
+        version: Version,
+    ) -> Job<UsesJob> {
+        Job {
+            config: UsesJob {
+                uses: format!(
+                    "{}/{}/{}@{}",
+                    owner.to_string(),
+                    repo.to_string(),
+                    path.to_string(),
+                    version.to_string()
+                ),
+                ..Default::default()
+            },
+            value: self.value,
+        }
     }
+}
 
-    /// Adds an environment variable to the job.
-    pub fn add_env<T: Into<Env>>(mut self, new_env: T) -> Self {
-        let mut env = self.env.take().unwrap_or_default();
-
-        env.0.extend(new_env.into().0);
-        self.env = Some(env);
-        self
-    }
-
-    pub fn add_needs<J: ToString>(mut self, job_id: J) -> Self {
-        if let Some(needs) = self.needs.as_mut() {
+impl<J: JobType> Job<J> {
+    pub fn add_needs<T: ToString>(mut self, job_id: T) -> Self {
+        if let Some(needs) = self.value.needs.as_mut() {
             needs.push(job_id.to_string());
         } else {
-            self.needs = Some(vec![job_id.to_string()]);
+            self.value.needs = Some(vec![job_id.to_string()]);
         }
         self
     }
+}
 
+impl Job<RunJob> {
     /// Adds an output to the job.
     pub fn add_output<K: ToString, V: ToString>(mut self, key: K, value: V) -> Self {
-        let mut outputs = self.outputs.take().unwrap_or_default();
+        let mut outputs = self.config.outputs.take().unwrap_or_default();
         outputs.insert(key.to_string(), value.to_string());
-        self.outputs = Some(outputs);
+        self.config.outputs = Some(outputs);
         self
     }
 
     /// Adds a service to the job.
     pub fn add_service<K: ToString, V: Into<Container>>(mut self, key: K, service: V) -> Self {
-        let mut services = self.services.take().unwrap_or_default();
+        let mut services = self.config.services.take().unwrap_or_default();
         services.insert(key.to_string(), service.into());
-        self.services = Some(services);
+        self.config.services = Some(services);
         self
     }
 
+    /// Adds a step to the job.
+    pub fn add_step<S: Into<Step<T>>, T: StepType>(mut self, step: S) -> Self {
+        let mut steps = self.config.steps.take().unwrap_or_default();
+        let step: Step<T> = step.into();
+        let step: StepValue = T::to_value(step);
+        steps.push(step);
+        self.config.steps = Some(steps);
+        self
+    }
+
+    /// Adds an environment variable to the job.
+    pub fn add_env<E: Into<Env>>(mut self, new_env: E) -> Self {
+        let mut env = self.config.env.take().unwrap_or_default();
+
+        env.0.extend(new_env.into().0);
+        self.config.env = Some(env);
+        self
+    }
+}
+
+impl Job<UsesJob> {
     /// Adds a new input to the job.
     pub fn add_with<I: Into<Input>>(mut self, new_with: I) -> Self {
-        let mut with = self.with.take().unwrap_or_default();
+        let mut with = self.config.with.take().unwrap_or_default();
         with.merge(new_with.into());
         if with.0.is_empty() {
-            self.with = None;
+            self.config.with = None;
         } else {
-            self.with = Some(with);
+            self.config.with = Some(with);
         }
 
         self
@@ -179,7 +329,7 @@ impl Job {
     /// Will silently drop any secrets added.
     /// Mutually exclusive with `add_secret`
     pub fn inherit_secrets(mut self) -> Self {
-        self.secrets = Some(Secrets::Inherit);
+        self.config.secrets = Some(Secrets::Inherit);
         self
     }
 
@@ -188,6 +338,7 @@ impl Job {
     /// Mutually exclusive with `inherit_secrets`
     pub fn add_secret<K: ToString, V: Into<String>>(mut self, key: K, secret: V) -> Self {
         let mut secrets = match self
+            .config
             .secrets
             .take()
             .unwrap_or(Secrets::Values(IndexMap::default()))
@@ -196,7 +347,7 @@ impl Job {
             Secrets::Values(values) => values,
         };
         secrets.insert(key.to_string(), secret.into());
-        self.secrets = Some(Secrets::Values(secrets));
+        self.config.secrets = Some(Secrets::Values(secrets));
         self
     }
 }
@@ -207,15 +358,27 @@ mod tests {
 
     #[test]
     fn test_job_default_sets_runs_on() {
-        let job = Job::default();
-        assert!(job.runs_on.is_some());
+        let value = RunJob::to_value(Job::default());
+        assert!(value.runs_on.is_some());
 
         // Verify it's set to "ubuntu-latest"
-        if let Some(runs_on) = job.runs_on {
+        if let Some(runs_on) = value.runs_on {
             assert_eq!(
                 runs_on.0,
                 serde_json::Value::String("ubuntu-latest".to_string())
             );
         }
+    }
+
+    #[test]
+    fn test_uses_job_has_no_runs_on() {
+        let job = Job::new("Reusable Job").uses("owner", "repo", ".github/workflows/ci.yml", "v1");
+        let value = UsesJob::to_value(job);
+
+        assert_eq!(
+            value.uses.as_deref(),
+            Some("owner/repo/.github/workflows/ci.yml@v1")
+        );
+        assert!(value.runs_on.is_none());
     }
 }

--- a/crates/gh-workflow/src/workflow.rs
+++ b/crates/gh-workflow/src/workflow.rs
@@ -14,14 +14,16 @@ use crate::error::Result;
 use crate::generate::Generate;
 use crate::job::Job;
 use crate::permissions::Permissions;
-use crate::Event;
+use crate::{Event, JobType, JobValue};
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(transparent)]
-pub struct Jobs(pub(crate) IndexMap<String, Job>);
+pub struct Jobs(pub(crate) IndexMap<String, JobValue>);
 impl Jobs {
-    pub fn add(mut self, key: String, value: Job) -> Self {
-        self.0.insert(key, value);
+    pub fn add<J: Into<Job<T>>, T: JobType>(mut self, key: String, value: J) -> Self {
+        let job: Job<T> = value.into();
+        let job: JobValue = T::to_value(job);
+        self.0.insert(key, job);
         self
     }
 
@@ -33,8 +35,8 @@ impl Jobs {
     ///
     /// # Returns
     ///
-    /// Returns `Some(&Job)` if the job exists, `None` otherwise.
-    pub fn get(&self, key: &str) -> Option<&Job> {
+    /// Returns `Some(&JobValue)` if the job exists, `None` otherwise.
+    pub fn get(&self, key: &str) -> Option<&JobValue> {
         self.0.get(key)
     }
 }
@@ -115,7 +117,7 @@ impl Workflow {
     }
 
     /// Adds a job to the workflow with the specified ID and job configuration.
-    pub fn add_job<T: ToString, J: Into<Job>>(mut self, id: T, job: J) -> Self {
+    pub fn add_job<I: ToString, J: Into<Job<T>>, T: JobType>(mut self, id: I, job: J) -> Self {
         let key = id.to_string();
         let jobs = self.jobs.take().unwrap_or_default().add(key, job.into());
 


### PR DESCRIPTION
Similar to how steps are handled, this PR introduces the same abstraction for jobs - since jobs invoking reusable workflows are vastly different from "normal" jobs, they share barely any configuration. However, with what is currently available, one could easily define a job that contained invalid combinations when working with reusable workflows (or for that matter, even with the more common type of workflows).

With the changes here, this adds a strict differentiation between the different kind of jobs by utilizing the type system, making invalid jobs unrepresentable.

We've been using this upstream in the Zed repo for quite some time now without any issues. I also contributed to `derive_setters` to make this properly possible in the first place (thus the bump in this PR). At the same time, I acknowledge this is a bigger change than the previous ones, happy to discuss this as needed.

Notably, a breaking change this introduces is that getting a job now returns a `JobValue` as opposed to a `Job` due to the change to the types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for defining reusable workflow jobs alongside standard run jobs.
  - Reusable workflow jobs can now specify workflow references, inputs, and secrets.
  - Standard jobs continue to support steps, environments, outputs, services, and dependencies.
  - Workflow job registration and serialization now support both job types.
- **Bug Fixes**
  - Improved reusable workflow serialization so it no longer requires a runner configuration.
  - Secret configuration now correctly applies to reusable workflow jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->